### PR TITLE
🐛 Fix incorrect comment time

### DIFF
--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -22,7 +22,7 @@ const CommentCard: Component<{ content: ReactiveComment; rootId: string }> = (pr
   );
   const [now] = createDateNow();
   const { locale, commentClassName } = configProvider;
-  const time = createMemo(() => getTimeAgo(props.content.insertedAt, now(), locale()));
+  const time = createMemo(() => getTimeAgo(new Date(props.content.time), now(), locale()));
   return (
     <div id={props.content.objectId} class="sds-comment flex p-2 pe-0">
       <div aria-hidden class="me-3 relative">

--- a/src/controllers/commentListState.ts
+++ b/src/controllers/commentListState.ts
@@ -78,6 +78,7 @@ export interface ReactiveComment extends Exclude<ReactiveCommentData, 'ua'> {
   level?: number;
   addr?: string;
   label?: string;
+  time: number;
   user_id?: string | number;
   status?: WalineCommentStatus;
   like: Accessor<number>;


### PR DESCRIPTION
👋 Left a comment on [your post](https://stblog.penclub.club/posts/ChineseOpenSourceWay/) but noticed the time was unaware of timezones, as it was doing `new Date(UTCTimeString)`, so fixed it with a timestamp instead. Hope you like it!

Before:

<img width="219" alt="image" src="https://github.com/BeiyanYunyi/sodesu/assets/44045911/f6dda0a5-4c58-46ba-8a2c-9b2e101e3599">

After:

<img width="223" alt="image" src="https://github.com/BeiyanYunyi/sodesu/assets/44045911/a591f220-148a-4841-bf22-6fceae2c444c">

By the way, instead of re-implementing [time functions](https://github.com/BeiyanYunyi/sodesu/blob/f500ff65f886585dd9fc1e0bff7a05888e1f4411/src/waline/utils/date.ts#L21), which is error-prone, you would probably want to use `Intl.RelativeTimeFormat` or `date-fns`-alike.